### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name" : "generator-buster",
+  "description": "Yeoman generator for BusterJS",
   "version" : "0.0.1",
   "keywords": [
     "yeoman-generator",
@@ -18,6 +19,7 @@
   "scripts": {
     "test": "mocha --reporter spec"
   },
+  "files": ["app/", "newtest/"],
   "dependencies": {
     "yeoman-generator": "~0.10.2"
   },
@@ -25,7 +27,11 @@
     "mocha": "~1.8.1"
   },
   "engines": {
-    "node": ">=0.8.0"
+    "node": ">=0.8.0",
+    "npm": ">=1.2.10"
+  },
+  "peerDependencies": {
+    "yo": ">=1.0.0-rc.1.1"
   },
   "licenses": [
     {


### PR DESCRIPTION
This adds:
- A description
- Files property, to not include tests in the module
- A peerDependency on `yo`, so the user does not have to manually install `yo` to get started. This is the new default for the official generators.
- A engine dependency on npm >= 1.2.10, so users get a warning if their npm version doesn't support peer dependencies yet.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/abiee/generator-buster/2)

<!-- Reviewable:end -->
